### PR TITLE
fix rendering of fields in templates

### DIFF
--- a/src/neapolitan/templatetags/neapolitan.py
+++ b/src/neapolitan/templatetags/neapolitan.py
@@ -39,7 +39,7 @@ def object_detail(object, fields):
     def iter():
         for f in fields:
             mf = object._meta.get_field(f)
-            yield (mf.verbose_name, mf.value_to_string(object))
+            yield (mf.verbose_name, str(getattr(object, f)))
 
     return {"object": iter()}
 
@@ -60,10 +60,8 @@ def object_list(objects, fields):
     headers = [objects[0]._meta.get_field(f).verbose_name for f in fields]
     object_list = [
         {
-            "object": {f: getattr(object, f) for f in fields},
-            "fields": [
-                {"name": f, "value": object._meta.get_field(f).value_to_string(object)} for f in fields
-            ],
+            "object": object,
+            "fields": [{"name": f, "value": str(getattr(object, f))} for f in fields],
             "actions": action_links(object),
         }
         for object in objects


### PR DESCRIPTION
The `value_to_string` field method on any relational field seems to print out the primary key of the object, rather than the string representation of the object. This PR changes the rendering of the field values to output the string instead.

Before:

<img width="384" alt="image" src="https://github.com/westerveltco/neapolitan/assets/19896267/7e66c88d-8e65-4367-97b3-a62f2353fdfd">

<img width="380" alt="image" src="https://github.com/westerveltco/neapolitan/assets/19896267/03d5b790-dbac-42b3-8715-bbdf95ff1414">

After:

<img width="397" alt="image" src="https://github.com/westerveltco/neapolitan/assets/19896267/043c156f-b8b8-4b6c-bc15-7c0cbccc5950">

<img width="392" alt="image" src="https://github.com/westerveltco/neapolitan/assets/19896267/41c552a4-c940-46b1-a156-c6bcd5f521ba">
